### PR TITLE
fix(filtering): make list operators non-nullable

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -12,8 +12,8 @@ input CommentFilter {
   text: StringInput
   description: StringInput
   noteId: IDInput
-  and: [CommentFilter]
-  or: [CommentFilter]
+  and: [CommentFilter!]
+  or: [CommentFilter!]
   not: CommentFilter
 }
 
@@ -50,7 +50,7 @@ input IDInput {
   lt: ID
   ge: ID
   gt: ID
-  in: [ID]
+  in: [ID!]
   contains: ID
   startsWith: ID
   endsWith: ID
@@ -92,8 +92,8 @@ input NoteFilter {
   id: IDInput
   title: StringInput
   description: StringInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 
@@ -139,7 +139,7 @@ input StringInput {
   lt: String
   ge: String
   gt: String
-  in: [String]
+  in: [String!]
   contains: String
   startsWith: String
   endsWith: String

--- a/docs/spec-find.md
+++ b/docs/spec-find.md
@@ -50,8 +50,8 @@ input NoteFilter {
   clickCount: IntInput
   floatValue: FloatInput
   description: StringInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 ```

--- a/docs/spec-subscriptions.md
+++ b/docs/spec-subscriptions.md
@@ -14,8 +14,8 @@ input NoteSubscriptionFilter {
   id: IDInput
   title: StringInput
   description: StringInput
-  and: [NoteFilter]
-  or: [NoteFilter]
+  and: [NoteFilter!]
+  or: [NoteFilter!]
   not: NoteFilter
 }
 


### PR DESCRIPTION
Reviewed filterable fields that use list after seeing #20 #16 and noticed a couple that had not been updated.

Also, applying the logic from #20 I have updated `and` and `or` to make the list non-null so that an empty list cannot be specified.