### PR TITLE
fix: wrong CRUD example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ For example, this GraphQL CRUD query retrieves a single user:
 
 ```graphql
 {
-  user(where: { id: 4 }) {
+  getUser(id: 4) {
     name
   }
 }


### PR DESCRIPTION
The intro section contains an example query that is not using GraphQLCRUD.